### PR TITLE
Fix README spelling error

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ yarn add jsx-no-react
 You'll also need to hook the `jsxElem` function into the JSX transformation, for which you should probably use [babel](https://www.npmjs.com/package/@babel/preset-react), which you can install and setup fairly simply:
 
 ```sh
-yarn add "@babel/preset-react babel-preset-env
+yarn add @babel/preset-react babel-preset-env
 ```
 
 and configure babel to correctly transform JSX with a `.babelrc` something like:


### PR DESCRIPTION
There was a typo in the README for the setup.