### PR TITLE
Add beforeend and afterend render options

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,25 @@ function Hello(props) {
 render(<Hello name="world" />, document.body);
 ```
 
+There are several ways to render an element:
+- `render`: which renders an element just after the beginning of the parent element
+- `renderBeforeEnd`: this function renders the JSX element before the end of the parent element.
+- `renderAfterEnd`: this function renders the JSX element after the end of the parent element.
+- `renderAndReplace`: this function renders the JSX element on parent element by replacing the content.
+
+```javascript
+import jsxElem, { render, renderAfterEnd, renderBeforeEnd, renderAndReplace } from "jsx-no-react";
+
+function Hello(props) {
+  return <h1>Hello {props.name}</h1>;
+}
+
+render(<Hello name="world" />, document.body);
+renderAfterEnd(<Hello name="world" />, document.body);
+renderBeforeEnd(<Hello name="world" />, document.body);
+renderAndReplace(<Hello name="world" />, document.body);
+```
+
 #### Composing Components
 
 Components can be reused and combined together.

--- a/src/module.js
+++ b/src/module.js
@@ -42,6 +42,14 @@ export function render(elem, parent) {
   parent.insertAdjacentElement("afterbegin", elem);
 }
 
+export function renderBeforeEnd(elem, parent) {
+  parent.insertAdjacentElement("beforeend", elem);
+}
+
+export function renderAfterEnd(elem, parent) {
+  parent.insertAdjacentElement("afterend", elem);
+}
+
 function addAttributes(elem, attrs) {
   if (attrs === null || attrs === undefined) attrs = {};
   for (let [attr, value] of Object.entries(attrs)) {
@@ -78,7 +86,7 @@ const createAndAppendSVG = (tag, attrs, ...children) => {
     const childElement = document.createElementNS('http://www.w3.org/2000/svg', child.nodeName.toLowerCase())
 
     for (const attribute of child.attributes) {
-      childElement.setAttributeNS(null,attribute.nodeName, attribute.nodeValue);
+      childElement.setAttributeNS(null, attribute.nodeName, attribute.nodeValue);
     }
 
     appendChild(element, childElement);
@@ -88,17 +96,17 @@ const createAndAppendSVG = (tag, attrs, ...children) => {
 }
 
 
-function converter(tag, attrs, ...children) { 
+function converter(tag, attrs, ...children) {
   if (tag === "svg") {
     return createAndAppendSVG(tag, attrs, ...children);
   }
 
   const elem = createElement(tag, attrs);
-  
+
   for (const child of children) {
     appendChild(elem, child);
   }
-  
+
   return elem;
 }
 

--- a/src/module.js
+++ b/src/module.js
@@ -50,6 +50,11 @@ export function renderAfterEnd(elem, parent) {
   parent.insertAdjacentElement("afterend", elem);
 }
 
+export function renderAndReplace(elem, parent) {
+  parent.innerHTML = "";
+  parent.insertAdjacentElement("afterbegin", elem);
+}
+
 function addAttributes(elem, attrs) {
   if (attrs === null || attrs === undefined) attrs = {};
   for (let [attr, value] of Object.entries(attrs)) {

--- a/src/module.test.js
+++ b/src/module.test.js
@@ -1,4 +1,4 @@
-import jsxElem, { render } from "./module";
+import jsxElem, { render, renderBeforeEnd, renderAfterEnd } from "./module";
 import expectExport from "expect";
 
 describe("jsxElement usage", () => {
@@ -100,7 +100,7 @@ describe("jsxElement usage", () => {
       <i>{[...Array(props.dots)].map(idx => ".")}</i>
     );
 
-    const element =  <div>
+    const element = <div>
       <Hello name="foo" />
       <CustomSeparator dots={50} />
       <Hello name="bar" />
@@ -118,7 +118,7 @@ describe("jsxElement usage", () => {
     }
 
     const element = <div><Hello /></div>;
-    
+
     expect(element.innerHTML).toEqual("<h1>Hello</h1><h1>world</h1>");
   });
 });
@@ -133,6 +133,38 @@ describe("render", () => {
     render(<Hello name="world" />, { insertAdjacentElement: mockElement });
     expect(mockElement.mock.calls.length).toBe(1);
     expect(mockElement.mock.calls[0][0]).toBe("afterbegin");
+    expect(mockElement.mock.calls[0][1].outerHTML).toEqual(
+      "<h1>Hello world</h1>"
+    );
+  });
+});
+
+describe("renderBeforeEnd", () => {
+  it("adds the output before the end of the element", () => {
+    function Hello(props) {
+      return <h1>Hello {props.name}</h1>;
+    }
+
+    const mockElement = jest.fn();
+    renderBeforeEnd(<Hello name="world" />, { insertAdjacentElement: mockElement });
+    expect(mockElement.mock.calls.length).toBe(1);
+    expect(mockElement.mock.calls[0][0]).toBe("beforeend");
+    expect(mockElement.mock.calls[0][1].outerHTML).toEqual(
+      "<h1>Hello world</h1>"
+    );
+  });
+});
+
+describe("renderAfterEnd", () => {
+  it("adds the output after rhe end of the element", () => {
+    function Hello(props) {
+      return <h1>Hello {props.name}</h1>;
+    }
+
+    const mockElement = jest.fn();
+    renderAfterEnd(<Hello name="world" />, { insertAdjacentElement: mockElement });
+    expect(mockElement.mock.calls.length).toBe(1);
+    expect(mockElement.mock.calls[0][0]).toBe("afterend");
     expect(mockElement.mock.calls[0][1].outerHTML).toEqual(
       "<h1>Hello world</h1>"
     );

--- a/src/module.test.js
+++ b/src/module.test.js
@@ -1,4 +1,4 @@
-import jsxElem, { render, renderBeforeEnd, renderAfterEnd } from "./module";
+import jsxElem, { render, renderBeforeEnd, renderAfterEnd, renderAndReplace } from "./module";
 import expectExport from "expect";
 
 describe("jsxElement usage", () => {
@@ -156,7 +156,7 @@ describe("renderBeforeEnd", () => {
 });
 
 describe("renderAfterEnd", () => {
-  it("adds the output after rhe end of the element", () => {
+  it("adds the output after the end of the element", () => {
     function Hello(props) {
       return <h1>Hello {props.name}</h1>;
     }
@@ -166,6 +166,21 @@ describe("renderAfterEnd", () => {
     expect(mockElement.mock.calls.length).toBe(1);
     expect(mockElement.mock.calls[0][0]).toBe("afterend");
     expect(mockElement.mock.calls[0][1].outerHTML).toEqual(
+      "<h1>Hello world</h1>"
+    );
+  });
+});
+
+describe("renderAndReplace", () => {
+  it("replace content and adds the output", () => {
+    function Hello(props) {
+      return <h1>Hello {props.name}</h1>;
+    }
+
+    const mockElement = document.createElement("div");
+    document.body.appendChild(mockElement);
+    renderAndReplace(<Hello name="world" />, document.body);
+    expect(document.body.innerHTML).toEqual(
       "<h1>Hello world</h1>"
     );
   });


### PR DESCRIPTION
## Problem

I want to be able to render JSX elements but after the content of the parent and sometimes by replacing the content.

## Solutions

- Set up three functions to be able to render `afterend`, `beforeend` and by replacing contents on the parent element.
- Adding Jest tests.